### PR TITLE
Center block build animation on the voxel origin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,3 +4,6 @@ plugins {
     id 'com.gtnewhorizons.gtnhconvention'
 }
 
+tasks.named('test') {
+    useJUnitPlatform()
+}

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -20,5 +20,5 @@ dependencies {
 
     testImplementation(platform('org.junit:junit-bom:5.9.2'))
     testImplementation('org.junit.jupiter:junit-jupiter')
-    testImplementation "org.junit.jupiter:junit-jupiter-api:5.4.0"
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
 }

--- a/src/main/java/com/direwolf20/buildinggadgets/common/entities/BlockBuildEntityRender.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/entities/BlockBuildEntityRender.java
@@ -46,9 +46,9 @@ public class BlockBuildEntityRender extends Render {
             scale = (float) (maxLife - teCounter) / maxLife;
         }
 
-        float trans = (1 - scale) / 2;
-
-        GL11.glTranslated(x + trans + 0.5, y + trans + 0.5, z + trans + 0.5);
+        // renderBlockAsItem centers ordinary block item geometry around local origin.
+        // Translate to the voxel center so scaling grows/shrinks in place.
+        GL11.glTranslated(centerOnBlock(x), centerOnBlock(y), centerOnBlock(z));
         GL11.glRotatef(-90.0F, 0.0F, 1.0F, 0.0F);
         GL11.glScalef(scale, scale, scale);
 
@@ -120,6 +120,10 @@ public class BlockBuildEntityRender extends Render {
 
         GL11.glPopMatrix();
         GL11.glPopAttrib();
+    }
+
+    static double centerOnBlock(double coordinate) {
+        return coordinate + 0.5D;
     }
 
     @Override

--- a/src/test/java/com/direwolf20/buildinggadgets/common/entities/BlockBuildEntityRenderTest.java
+++ b/src/test/java/com/direwolf20/buildinggadgets/common/entities/BlockBuildEntityRenderTest.java
@@ -1,0 +1,43 @@
+package com.direwolf20.buildinggadgets.common.entities;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class BlockBuildEntityRenderTest {
+
+    private static final double DELTA = 1e-6D;
+
+    @Test
+    void translateToVoxelCenter() {
+        assertEquals(10.5D, BlockBuildEntityRender.centerOnBlock(10.0D), DELTA);
+    }
+
+    @ParameterizedTest
+    @ValueSource(floats = { 0.1F, 0.25F, 0.5F, 0.75F, 0.9F, 0.99F })
+    void centeredItemGeometryStaysCenteredWhileScaling(float scale) {
+        double blockPosition = 10.0D;
+        double translation = BlockBuildEntityRender.centerOnBlock(blockPosition);
+
+        // RenderBlocks.renderBlockAsItem shifts ordinary block item geometry by -0.5,
+        // so its local center is 0 and remains 0 under uniform scale.
+        double renderedCenter = translation;
+
+        assertEquals(blockPosition + 0.5D, renderedCenter, DELTA);
+    }
+
+    @ParameterizedTest
+    @ValueSource(floats = { 0.1F, 0.25F, 0.5F, 0.75F, 0.9F, 0.99F })
+    void scaleDependentTranslationsDriftFromVoxelCenter(float scale) {
+        double blockPosition = 10.0D;
+        double offset = (1.0D - scale) / 2.0D;
+
+        double oldCenter = blockPosition + 0.5D + offset;
+        double copilotPrCenter = blockPosition + offset;
+
+        assertEquals(offset, oldCenter - (blockPosition + 0.5D), DELTA);
+        assertEquals(0.5D - offset, (blockPosition + 0.5D) - copilotPrCenter, DELTA);
+    }
+}


### PR DESCRIPTION
## Summary
- Anchor the block build entity render at the voxel center instead of using the scale-dependent translation offset.
- Add a focused unit test for the render centering math.
- Enable JUnit Platform execution and align the test runtime dependencies so the new tests run under Gradle.

## Testing
- `./gradlew test` passed.
- `./gradlew runClient21` launched successfully for local visual validation.