### PR TITLE
[codex] Add original building gadget recipes

### DIFF
--- a/src/main/java/com/direwolf20/buildinggadgets/CommonProxy.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/CommonProxy.java
@@ -2,6 +2,7 @@ package com.direwolf20.buildinggadgets;
 
 import com.direwolf20.buildinggadgets.client.gui.GuiProxy;
 import com.direwolf20.buildinggadgets.common.blocks.ModBlocks;
+import com.direwolf20.buildinggadgets.common.crafting.ModRecipes;
 import com.direwolf20.buildinggadgets.common.entities.ModEntities;
 import com.direwolf20.buildinggadgets.common.integration.IntegrationHandler;
 import com.direwolf20.buildinggadgets.common.items.ModItems;
@@ -28,6 +29,7 @@ public class CommonProxy {
     }
 
     public void init(FMLInitializationEvent event) {
+        ModRecipes.init();
         NetworkRegistry.INSTANCE.registerGuiHandler(BuildingGadgets.instance, new GuiProxy());
     }
 

--- a/src/main/java/com/direwolf20/buildinggadgets/common/crafting/ConstructionPasteContainerUpgradeRecipe.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/crafting/ConstructionPasteContainerUpgradeRecipe.java
@@ -1,0 +1,33 @@
+package com.direwolf20.buildinggadgets.common.crafting;
+
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.oredict.ShapedOreRecipe;
+
+import com.direwolf20.buildinggadgets.common.items.pastes.GenericPasteContainer;
+
+public class ConstructionPasteContainerUpgradeRecipe extends ShapedOreRecipe {
+
+    public ConstructionPasteContainerUpgradeRecipe(ItemStack result, Object... recipe) {
+        super(result, recipe);
+    }
+
+    @Override
+    public ItemStack getCraftingResult(InventoryCrafting inventory) {
+        ItemStack output = super.getCraftingResult(inventory);
+        if (output == null) {
+            return null;
+        }
+
+        int totalPaste = 0;
+        for (int slot = 0; slot < inventory.getSizeInventory(); slot++) {
+            ItemStack ingredient = inventory.getStackInSlot(slot);
+            if (ingredient != null && ingredient.getItem() instanceof GenericPasteContainer) {
+                totalPaste += GenericPasteContainer.getPasteAmount(ingredient);
+            }
+        }
+
+        GenericPasteContainer.setPasteAmount(output, totalPaste);
+        return output;
+    }
+}

--- a/src/main/java/com/direwolf20/buildinggadgets/common/crafting/ModRecipes.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/crafting/ModRecipes.java
@@ -1,0 +1,164 @@
+package com.direwolf20.buildinggadgets.common.crafting;
+
+import net.minecraft.init.Blocks;
+import net.minecraft.init.Items;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.oredict.OreDictionary;
+import net.minecraftforge.oredict.RecipeSorter;
+import net.minecraftforge.oredict.ShapedOreRecipe;
+import net.minecraftforge.oredict.ShapelessOreRecipe;
+
+import com.direwolf20.buildinggadgets.BuildingGadgets;
+import com.direwolf20.buildinggadgets.BuildingGadgetsConfig.GeneralConfig;
+import com.direwolf20.buildinggadgets.BuildingGadgetsConfig.PasteConfig;
+import com.direwolf20.buildinggadgets.common.blocks.ModBlocks;
+import com.direwolf20.buildinggadgets.common.items.ModItems;
+
+import cpw.mods.fml.common.registry.GameRegistry;
+
+public final class ModRecipes {
+
+    private ModRecipes() {}
+
+    public static void init() {
+        RecipeSorter.register(
+            BuildingGadgets.MODID + ":construction_paste_container_upgrade",
+            ConstructionPasteContainerUpgradeRecipe.class,
+            RecipeSorter.Category.SHAPED,
+            "after:minecraft:shaped");
+
+        registerGadgetRecipes();
+        registerTemplateManagerRecipe();
+
+        if (GeneralConfig.enableDestructionGadget) {
+            registerDestructionGadgetRecipe();
+        }
+
+        if (PasteConfig.enablePaste) {
+            registerConstructionPasteRecipes();
+        }
+    }
+
+    private static void registerGadgetRecipes() {
+        GameRegistry.addRecipe(
+            new ShapedOreRecipe(
+                new ItemStack(ModItems.gadgetBuilding),
+                "iri",
+                "drd",
+                "ili",
+                'i',
+                "ingotIron",
+                'r',
+                "dustRedstone",
+                'd',
+                "gemDiamond",
+                'l',
+                "gemLapis"));
+
+        GameRegistry.addRecipe(
+            new ShapedOreRecipe(
+                new ItemStack(ModItems.gadgetExchanger),
+                "iri",
+                "dld",
+                "ili",
+                'i',
+                "ingotIron",
+                'r',
+                "dustRedstone",
+                'd',
+                "gemDiamond",
+                'l',
+                "gemLapis"));
+
+        GameRegistry.addRecipe(
+            new ShapedOreRecipe(
+                new ItemStack(ModItems.gadgetCopyPaste),
+                "iri",
+                "ere",
+                "ili",
+                'i',
+                "ingotIron",
+                'r',
+                "dustRedstone",
+                'e',
+                "gemEmerald",
+                'l',
+                "gemLapis"));
+    }
+
+    private static void registerDestructionGadgetRecipe() {
+        GameRegistry.addRecipe(
+            new ShapedOreRecipe(
+                new ItemStack(ModItems.gadgetDestruction),
+                "iri",
+                "ere",
+                "ili",
+                'i',
+                "ingotIron",
+                'r',
+                "dustRedstone",
+                'e',
+                Items.ender_pearl,
+                'l',
+                "gemLapis"));
+    }
+
+    private static void registerTemplateManagerRecipe() {
+        GameRegistry.addRecipe(
+            new ShapedOreRecipe(
+                new ItemStack(ModBlocks.templateManager),
+                "iri",
+                "ere",
+                "ili",
+                'i',
+                "ingotGold",
+                'r',
+                "dustRedstone",
+                'e',
+                "gemEmerald",
+                'l',
+                "gemLapis"));
+    }
+
+    private static void registerConstructionPasteRecipes() {
+        GameRegistry.addRecipe(
+            new ShapedOreRecipe(
+                new ItemStack(ModItems.constructionPasteContainer),
+                "iii",
+                "iri",
+                "iii",
+                'i',
+                "ingotIron",
+                'r',
+                ModItems.constructionPaste));
+
+        GameRegistry.addRecipe(
+            new ConstructionPasteContainerUpgradeRecipe(
+                new ItemStack(ModItems.constructionPasteContainerT2),
+                "cgc",
+                "ggg",
+                "cgc",
+                'g',
+                "ingotGold",
+                'c',
+                new ItemStack(ModItems.constructionPasteContainer, 1, OreDictionary.WILDCARD_VALUE)));
+
+        GameRegistry.addRecipe(
+            new ConstructionPasteContainerUpgradeRecipe(
+                new ItemStack(ModItems.constructionPasteContainerT3),
+                "cgc",
+                "ggg",
+                "cgc",
+                'g',
+                "gemDiamond",
+                'c',
+                new ItemStack(ModItems.constructionPasteContainerT2, 1, OreDictionary.WILDCARD_VALUE)));
+
+        GameRegistry.addRecipe(
+            new ShapelessOreRecipe(
+                new ItemStack(ModBlocks.constructionBlockPowder),
+                new ItemStack(Blocks.sand, 1, 0),
+                "gemLapis",
+                Items.clay_ball));
+    }
+}


### PR DESCRIPTION
## Summary

- Register the original Building Gadgets 1.12.x crafting recipes in the 1.7.10 backport.
- Add a custom paste-container upgrade recipe so stored construction paste carries into upgraded containers.
- Wire recipe registration into common initialization and register the custom recipe with Forge's RecipeSorter.

## Validation

- ./gradlew compileJava
- ./gradlew assemble
- ./gradlew runClient21 manual verification: recipes appeared to work correctly in-game

Note: ./gradlew build is still blocked by an existing Spotless complaint in GadgetGeneric.java, and ./gradlew test is blocked by the repo's current no-discovered-tests Gradle configuration.